### PR TITLE
Add extend command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ SET CLUSTER SETTING
 # Open a sql connection to the first node.
 $ cockroach sql --insecure --host=35.196.94.196
 
+# Extend lifetime by another 6 hours.
+$ roachprod extend test --lifetime=6h
+
 # Destroy cluster
 $ roachprod destroy test
 Destroying cluster marc-test with 4 nodes

--- a/cluster.go
+++ b/cluster.go
@@ -29,22 +29,27 @@ func newCloud() *Cloud {
 type Cluster struct {
 	Name string
 	User string
-	// This is the earliest of all VM expirations.
-	Expiration time.Time
-	VMs        VMList
+	// This is the earliest creation and shortest lifetime across VMs.
+	CreatedAt time.Time
+	Lifetime  time.Duration
+	VMs       VMList
 }
 
-func (c *Cluster) Lifetime() time.Duration {
-	return time.Until(c.Expiration)
+func (c *Cluster) ExpiresAt() time.Time {
+	return c.CreatedAt.Add(c.Lifetime)
+}
+
+func (c *Cluster) LifetimeRemaining() time.Duration {
+	return time.Until(c.ExpiresAt())
 }
 
 func (c *Cluster) String() string {
-	return fmt.Sprintf("%s: %d (%s)", c.Name, len(c.VMs), c.Lifetime().Round(time.Second))
+	return fmt.Sprintf("%s: %d (%s)", c.Name, len(c.VMs), c.LifetimeRemaining().Round(time.Second))
 }
 
 func (c *Cluster) PrintDetails() {
 	fmt.Printf("%s: ", c.Name)
-	l := c.Lifetime().Round(time.Second)
+	l := c.LifetimeRemaining().Round(time.Second)
 	if l <= 0 {
 		fmt.Printf("expired %s ago\n", -l)
 	} else {
@@ -56,10 +61,11 @@ func (c *Cluster) PrintDetails() {
 }
 
 type VM struct {
-	Name       string
-	Expiration time.Time
-	PrivateIP  string
-	PublicIP   string
+	Name      string
+	CreatedAt time.Time
+	Lifetime  time.Duration
+	PrivateIP string
+	PublicIP  string
 }
 
 type VMList []VM
@@ -93,18 +99,18 @@ func listCloud() (*Cloud, error) {
 		}
 
 		// Check "lifetime" label.
-		lifetime, ok := vm.Labels["lifetime"]
+		lifetimeStr, ok := vm.Labels["lifetime"]
 		if !ok {
 			cloud.NoExpiration = append(cloud.NoExpiration, vm)
 			continue
 		}
 
-		dur, err := time.ParseDuration(lifetime)
+		lifetime, err := time.ParseDuration(lifetimeStr)
 		if err != nil {
 			cloud.NoExpiration = append(cloud.NoExpiration, vm)
 			continue
 		}
-		expiration := vm.CreationTimestamp.Add(dur)
+		createdAt := vm.CreationTimestamp
 
 		// Check private/public IPs.
 		if len(vm.NetworkInterfaces) == 0 || len(vm.NetworkInterfaces[0].AccessConfigs) == 0 {
@@ -121,22 +127,27 @@ func listCloud() (*Cloud, error) {
 
 		if _, ok := cloud.Clusters[clusterName]; !ok {
 			cloud.Clusters[clusterName] = &Cluster{
-				Name:       clusterName,
-				User:       userName,
-				Expiration: expiration,
-				VMs:        make([]VM, 0),
+				Name:      clusterName,
+				User:      userName,
+				CreatedAt: createdAt,
+				Lifetime:  lifetime,
+				VMs:       make([]VM, 0),
 			}
 		}
 
 		c := cloud.Clusters[clusterName]
 		c.VMs = append(c.VMs, VM{
-			Name:       vm.Name,
-			Expiration: expiration,
-			PrivateIP:  privateIP,
-			PublicIP:   publicIP,
+			Name:      vm.Name,
+			CreatedAt: createdAt,
+			Lifetime:  lifetime,
+			PrivateIP: privateIP,
+			PublicIP:  publicIP,
 		})
-		if expiration.Before(c.Expiration) {
-			c.Expiration = expiration
+		if createdAt.Before(c.CreatedAt) {
+			c.CreatedAt = createdAt
+		}
+		if lifetime < c.Lifetime {
+			c.Lifetime = lifetime
 		}
 	}
 
@@ -165,4 +176,14 @@ func destroyCluster(c *Cluster) error {
 	}
 
 	return deleteVMs(vmNames)
+}
+
+func extendCluster(c *Cluster, extension time.Duration) error {
+	newLifetime := c.Lifetime + extension
+	for _, vm := range c.VMs {
+		if err := extendVM(vm.Name, newLifetime); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/gcloud.go
+++ b/gcloud.go
@@ -159,6 +159,23 @@ func deleteVMs(names []string) error {
 	return nil
 }
 
+func extendVM(name string, lifetime time.Duration) error {
+	args := []string{"compute", "instances", "add-labels"}
+
+	args = append(args, "--project", project)
+	args = append(args, "--zone", zone)
+	args = append(args, "--labels", fmt.Sprintf("lifetime=%s", lifetime))
+	args = append(args, name)
+
+	cmd := exec.Command("gcloud", args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+	return nil
+}
+
 func cleanSSH() error {
 	args := []string{"compute", "config-ssh", "--project", project, "--quiet", "--remove"}
 	cmd := exec.Command("gcloud", args...)

--- a/monitor.go
+++ b/monitor.go
@@ -49,7 +49,7 @@ func monitorClusters(cloud *Cloud, filename string, destroyAfter time.Duration) 
 		}
 
 		actions := userActions[c.User]
-		exp := c.Expiration
+		exp := c.ExpiresAt()
 
 		if exp.After(now) {
 			// Hasn't reached deadline yet.


### PR DESCRIPTION
Fixes #12.

Extends lifetime of all VMs in the cluster by a default of 12h
(`--lifetime`).

Unfortunately, gcloud has to be called on every instance, so it's a bit
slow.