### PR TITLE
Add a restore-prebuilt-data-dir command

### DIFF
--- a/main.go
+++ b/main.go
@@ -825,6 +825,21 @@ The "status" command outputs the binary and PID for the specified nodes:
 	}),
 }
 
+var restorePrebuiltDataDirCmd = &cobra.Command{
+	Use:   "restore-prebuilt-data-dir",
+	Short: "",
+	Long:  ` ` + tagHelp + ` `,
+	Args:  cobra.ExactArgs(2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.RestorePrebuiltDataDir(args[1])
+		return nil
+	}),
+}
+
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
 	Short: "monitor the status of nodes in a cluster",
@@ -1234,6 +1249,8 @@ func main() {
 		sqlCmd,
 		pgurlCmd,
 		adminurlCmd,
+
+		restorePrebuiltDataDirCmd,
 
 		webCmd,
 		dumpCmd,


### PR DESCRIPTION
The new command restores saved data dirs onto a new cluster. The dirs
are supposed to come from another cluster where a desired data set has
been loaded.
This speeds-up the "restore" of the TPCC-1000 fixture from ~40m to ~2m
on a 4 node cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/195)
<!-- Reviewable:end -->
